### PR TITLE
chore: Add @JatinSanghvi instead of @zroubalik as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
-*       @ahmelsayed @zroubalik @tomkerkhove
+*       @ahmelsayed @JatinSanghvi @tomkerkhove


### PR DESCRIPTION
Add @JatinSanghvi instead of @zroubalik as code owner so we don't disturb him.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)