### PR TITLE
Managed Identity + Workload Identity support.

### DIFF
--- a/deploy/deploy-scaledobject-cs.yaml
+++ b/deploy/deploy-scaledobject-cs.yaml
@@ -1,0 +1,22 @@
+# Template scaled-object for using KEDA external scaler for Azure Cosmos DB, using connection strings.
+
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: <scaledobject-name>
+  namespace: default
+spec:
+  pollingInterval: 20
+  scaleTargetRef:
+    name: <application-deployment-name>
+  triggers:
+    - type: external
+      metadata:
+        scalerAddress: external-scaler-azure-cosmos-db.keda:4050
+        databaseId: <database-id>
+        containerId: <container-id>
+        leaseDatabaseId: <lease-database-id>
+        leaseContainerId: <lease-container-id>
+        connectionFromEnv: <env-variable-for-connection-string-of-monitored-container-account>
+        leaseConnectionFromEnv: <env-variable-for-connection-string-of-lease-container-account>
+        processorName: <processor-name>

--- a/deploy/deploy-scaledobject-mi.yaml
+++ b/deploy/deploy-scaledobject-mi.yaml
@@ -1,4 +1,4 @@
-# Template scaled-object for using KEDA external scaler for Azure Cosmos DB.
+# Template scaled-object for using KEDA external scaler for Azure Cosmos DB, using connection strings.
 
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -13,10 +13,11 @@ spec:
     - type: external
       metadata:
         scalerAddress: external-scaler-azure-cosmos-db.keda:4050
-        connectionFromEnv: <env-variable-for-connection-string-of-monitored-container-account>
         databaseId: <database-id>
         containerId: <container-id>
-        leaseConnectionFromEnv: <env-variable-for-connection-string-of-lease-container-account>
         leaseDatabaseId: <lease-database-id>
         leaseContainerId: <lease-container-id>
+        endpoint: <endpoint>
+        leaseEndpoint: <leaseEndpoint>
+        clientId: <clientId>
         processorName: <processor-name>

--- a/src/Scaler/Keda.CosmosDb.Scaler.csproj
+++ b/src/Scaler/Keda.CosmosDb.Scaler.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+	<PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.67.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />

--- a/src/Scaler/Services/CosmosDbFactory.cs
+++ b/src/Scaler/Services/CosmosDbFactory.cs
@@ -1,22 +1,49 @@
 using System.Collections.Concurrent;
+
+using Azure.Core;
+using Azure.Identity;
 using Microsoft.Azure.Cosmos;
 
 namespace Keda.CosmosDb.Scaler
 {
     internal sealed class CosmosDbFactory
     {
+        private const string _applicationName = "keda-external-azure-cosmos-db";
         // As per https://docs.microsoft.com/dotnet/api/microsoft.azure.cosmos.cosmosclient, it is recommended to
         // maintain a single instance of CosmosClient per lifetime of the application.
-        private readonly ConcurrentDictionary<string, CosmosClient> _cosmosClientCache = new();
+        private readonly ConcurrentDictionary<(string, string), CosmosClient> _cosmosClientCache = new();
 
-        public CosmosClient GetCosmosClient(string connection)
+        public CosmosClient GetCosmosClient(string endpointOrConnection, bool useCredentials, string clientId)
         {
-            return _cosmosClientCache.GetOrAdd(connection, CreateCosmosClient);
+            return _cosmosClientCache.GetOrAdd((endpointOrConnection, clientId), CreateCosmosClient(endpointOrConnection, useCredentials, clientId));
         }
 
-        private CosmosClient CreateCosmosClient(string connection)
+        private CosmosClient CreateCosmosClient(string endpointOrConnection, bool useCredentials, string clientId)
         {
-            return new CosmosClient(connection, new CosmosClientOptions { ConnectionMode = ConnectionMode.Gateway });
+            if (useCredentials)
+            {
+                var credential = GetChainedCredential(clientId);
+                return new CosmosClient(endpointOrConnection, credential, new CosmosClientOptions { ConnectionMode = ConnectionMode.Gateway, ApplicationName = _applicationName });
+            }
+            else
+            {
+                return new CosmosClient(endpointOrConnection, new CosmosClientOptions { ConnectionMode = ConnectionMode.Gateway, ApplicationName = _applicationName });
+            }
+        }
+
+        /// <summary>
+        /// Returns a chained token credential to be used for authentication. Supports managed identity, workload identity credentials
+        /// on Azure, while az CLI credentials can be used for local testing.
+        /// </summary>
+        /// <param name="clientId">ClientId of the identity to be used. System identity is used if this is null. </param>
+        /// <returns></returns>
+        private TokenCredential GetChainedCredential(string clientId)
+        {
+            var managedIdentityCredentials = new ManagedIdentityCredential(clientId: clientId);
+            var workloadIdentityCredentials = new WorkloadIdentityCredential(new WorkloadIdentityCredentialOptions { ClientId = clientId });
+            var azCliCredentials = new AzureCliCredential();
+
+            return new ChainedTokenCredential(managedIdentityCredentials, workloadIdentityCredentials, azCliCredentials);
         }
     }
 }

--- a/src/Scaler/Services/CosmosDbMetricProvider.cs
+++ b/src/Scaler/Services/CosmosDbMetricProvider.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
 
@@ -19,22 +20,32 @@ namespace Keda.CosmosDb.Scaler
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
+        private CosmosClient GetCosmosClientFromMetadata(ScalerMetadata metadata)
+        {
+            // Prioritize credential based connections
+            if (!string.IsNullOrWhiteSpace(metadata.Endpoint))
+            {
+                return _factory.GetCosmosClient(metadata.Endpoint, useCredentials: true, clientId: metadata.ClientId);
+            }
+            else
+            {
+                return _factory.GetCosmosClient(metadata.Connection , useCredentials: false, clientId: null);
+            }
+        }
+
         public async Task<long> GetPartitionCountAsync(ScalerMetadata scalerMetadata)
         {
             try
             {
-                Container leaseContainer = _factory
-                    .GetCosmosClient(scalerMetadata.LeaseConnection)
+                Container leaseContainer = GetCosmosClientFromMetadata(scalerMetadata)
                     .GetContainer(scalerMetadata.LeaseDatabaseId, scalerMetadata.LeaseContainerId);
 
-                ChangeFeedEstimator estimator = _factory
-                    .GetCosmosClient(scalerMetadata.Connection)
+                ChangeFeedEstimator estimator = GetCosmosClientFromMetadata(scalerMetadata)
                     .GetContainer(scalerMetadata.DatabaseId, scalerMetadata.ContainerId)
                     .GetChangeFeedEstimator(scalerMetadata.ProcessorName, leaseContainer);
 
                 // It does not help by creating more change-feed processing instances than the number of partitions.
                 int partitionCount = 0;
-
                 using (FeedIterator<ChangeFeedProcessorState> iterator = estimator.GetCurrentStateIterator())
                 {
                     while (iterator.HasMoreResults)

--- a/src/Scaler/Services/ScalerMetadata.cs
+++ b/src/Scaler/Services/ScalerMetadata.cs
@@ -14,61 +14,59 @@ namespace Keda.CosmosDb.Scaler
         /// <summary>
         /// ID of Cosmos DB database containing monitored container.
         /// </summary>
-        [JsonProperty(Required = Required.Always)]
         [JsonRequired]
         public string DatabaseId { get; set; }
 
         /// <summary>
         /// ID of monitored container.
         /// </summary>
-        [JsonProperty(Required = Required.Always)]
         public string ContainerId { get; set; }
 
         /// <summary>
         /// ID of Cosmos DB database containing lease container.
         /// </summary>
-        [JsonProperty(Required = Required.Always)]
         public string LeaseDatabaseId { get; set; }
 
         /// <summary>
         /// ID of lease container.
         /// </summary>
-        [JsonProperty(Required = Required.Always)]
         public string LeaseContainerId { get; set; }
 
         // Connection String properties
         /// <summary>
         /// Environment variable for the connection string of Cosmos DB account with monitored container.
         /// </summary>
-        [JsonProperty("ConnectionFromEnv")]
+        [JsonProperty("ConnectionFromEnv", Required = Required.Default)]
         public string Connection { get; set; }
 
         /// <summary>
         /// Environment variable for the connection string of Cosmos DB account with lease container.
         /// </summary>
-        [JsonProperty("LeaseConnectionFromEnv")]
+        [JsonProperty("LeaseConnectionFromEnv", Required = Required.Default)]
         public string LeaseConnection { get; set; }
 
         // Managed Identity properties
         /// <summary>
         /// Account endpoint of the CosmosDB account containing the monitored container.
         /// </summary>
+        [JsonProperty(Required = Required.Default)]
         public string Endpoint { get; set; }
 
         /// <summary>
         /// Account endpoint of the CosmosDB account containing the lease container.
         /// </summary>
+        [JsonProperty(Required = Required.Default)]
         public string LeaseEndpoint { get; set; }
 
         /// <summary>
         /// ClientId of the identity to be used. System assigned identity is used, if this is null.
         /// </summary>
+        [JsonProperty(Required = Required.Default)]
         public string ClientId { get; set; }
 
         /// <summary>
         /// Name of change-feed processor used by listener application.
         /// </summary>
-        [JsonProperty(Required = Required.Always)]
         public string ProcessorName { get; set; }
 
         [JsonProperty(Required = Required.DisallowNull)]

--- a/src/Scaler/deploy.yaml
+++ b/src/Scaler/deploy.yaml
@@ -10,6 +10,8 @@ spec:
   selector:
     matchLabels:
       app: cosmosdb-scaler
+      # Optional: Use Workload Identity for authentication. Refer https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html for more details.
+      azure.workload.identity/use: true 
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR adds support for the following ways to connect to the CosmosDB database:
- Managed Identity (when running on platform on an Azure PaaS)
- Workload Identity (when running on AKS / other kubernetes clusters)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Fixes #49
